### PR TITLE
added the "updated" element to the sync_state.json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 [![Gem Version](https://badge.fury.io/rb/jirasync.svg)](http://badge.fury.io/rb/jirasync)
 
+## Intent of this fork ....
+
+I'm looking at adding a docx generator in addition to some mods to the markdown generator.
+
 ## Installation
 
     gem install jirasync
@@ -53,10 +57,10 @@ jira-sync \
 
 ### Fetching and Storing Attachments
 
- 
+
 Passing in the `--store-attachments` option leads to attachments being fetched and stored in the local filesystem.
 They will we be stored in the `attachments/` sub-directory of the target directory.
- 
+
 ### Formatting Issues
 
 While JSON files are very handy to use in code, they are not very readable. The `jira-format-issues` command

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,1 @@
-task :default => :build
-
-task :build do
-    system "gem build jirasync.gemspec"
-end
+require "bundler/gem_tasks"

--- a/lib/jirasync/syncer.rb
+++ b/lib/jirasync/syncer.rb
@@ -78,7 +78,7 @@ module JiraSync
                 STDERR.puts( state['errors'].join(","))
             end
             keys_with_errors = fetch(issues + state['errors'])
-            @repo.save_state({"time" => start_time, "errors" => keys_with_errors})
+            @repo.save_state({"time" => start_time, "errors" => keys_with_errors, 'updated' => issues})
         end
 
         def dump()


### PR DESCRIPTION
Calling your attention to the change I made in the  lib/jirasync/syncer.rb file at line #81 where I've added the "updated" element to the sync_state.json file.  This element can now be used by downstream products to post-process updated tickets.

I'm sorry I did not create this patch as a feature branch.  I was in a hurry back then.  Please ignore the change to the README file.  That was just a reminder to myself of why I forked your repo in the first place.